### PR TITLE
[CCUBE-1064][SR] Amending bug which does not update child entry component UI properly when adding a new child component after changes are saved in RHF

### DIFF
--- a/src/components/element-editor/conditional-rendering/conditional-rendering.styles.tsx
+++ b/src/components/element-editor/conditional-rendering/conditional-rendering.styles.tsx
@@ -10,7 +10,7 @@ export const FieldWrapper = styled.div`
 
 export const SelectFieldContainer = styled.div`
     display: grid;
-    grid-template-columns: 6fr 3fr;
+    grid-template-columns: 5fr 4.5fr;
     gap: 1rem;
 `;
 

--- a/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
+++ b/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
@@ -95,14 +95,6 @@ export const ConditionalRendering = () => {
         );
         setValue("conditionalRendering", updatedChildEntries);
         setChildEntryValues(updatedChildEntries);
-    }, [focusedElement]);
-
-    useEffect(() => {
-        setChildEntryValues(
-            element?.conditionalRendering !== undefined
-                ? element?.conditionalRendering
-                : []
-        );
     }, [element]);
 
     useEffect(() => {
@@ -120,7 +112,7 @@ export const ConditionalRendering = () => {
     // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
-
+    console.log("check updated value:", childEntryValues);
     const renderChildren = () => {
         return childEntryValues?.map((child, index) => (
             <ConditionalRenderingChild

--- a/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
+++ b/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
@@ -112,7 +112,6 @@ export const ConditionalRendering = () => {
     // =============================================================================
     // RENDER FUNCTIONS
     // =============================================================================
-    console.log("check updated value:", childEntryValues);
     const renderChildren = () => {
         return childEntryValues?.map((child, index) => (
             <ConditionalRenderingChild


### PR DESCRIPTION
**Changes**
- Amending dependency to track element in focusedElement, and removed a useEffect to setChildEntry values as RHF value as it is already done in another useEffect.

**Additional information**
-   Found this bug when testing CCUBE-1064 in the dev environment
