### PR TITLE
CCUBE-1480, CCUBE-1466

### DIFF
--- a/src/components/element-editor/basic-details/basic-details.tsx
+++ b/src/components/element-editor/basic-details/basic-details.tsx
@@ -60,6 +60,7 @@ export const BasicDetails = () => {
                             errorMessage={errors.type?.message}
                         />
                     )}
+                    shouldUnregister={true}
                 />
 
                 {hasProperty("label") && (
@@ -81,6 +82,7 @@ export const BasicDetails = () => {
                                 maxLength={40}
                             />
                         )}
+                        shouldUnregister={true}
                     />
                 )}
 
@@ -98,6 +100,7 @@ export const BasicDetails = () => {
                                 id={element.internalId}
                             />
                         )}
+                        shouldUnregister={true}
                     />
 
                     {watch("required", true) && (
@@ -117,6 +120,7 @@ export const BasicDetails = () => {
                                     }
                                 />
                             )}
+                            shouldUnregister={true}
                         />
                     )}
                 </MandatoryFieldBox>
@@ -144,6 +148,7 @@ export const BasicDetails = () => {
                             errorMessage={errors.id?.message}
                         />
                     )}
+                    shouldUnregister={true}
                 />
 
                 {element?.hasOwnProperty("placeholder") && (
@@ -162,6 +167,7 @@ export const BasicDetails = () => {
                                 errorMessage={errors.placeholder?.message}
                             />
                         )}
+                        shouldUnregister={true}
                     />
                 )}
             </Wrapper>

--- a/src/components/element-editor/basic-details/basic-details.tsx
+++ b/src/components/element-editor/basic-details/basic-details.tsx
@@ -1,6 +1,5 @@
 import { Form } from "@lifesg/react-design-system/form";
 import { Text } from "@lifesg/react-design-system/text";
-import { useEffect } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { IconDropdown } from "src/components/common/icon-dropdown";
 import { TogglePair } from "src/components/common/toggle-pair/toggle-pair";
@@ -16,12 +15,12 @@ export const BasicDetails = () => {
     // =========================================================================
     // CONST, STATE, REFS
     // =========================================================================
-    const { focusedElement, updateFocusedElement } = useBuilder();
+    const { focusedElement } = useBuilder();
     const {
         control,
-        formState: { errors, isDirty },
+        formState: { errors },
         watch,
-        reset,
+        setValue,
     } = useFormContext<IBaseTextBasedFieldValues>();
     const element = focusedElement.element;
 
@@ -32,21 +31,6 @@ export const BasicDetails = () => {
     const hasProperty = (key: string) => {
         return key in element;
     };
-
-    // =========================================================================
-    // USE EFFECTS
-    // =========================================================================
-
-    useEffect(() => {
-        updateFocusedElement(!!isDirty);
-    }, [isDirty, updateFocusedElement]);
-
-    useEffect(() => {
-        reset(element, {
-            keepDirty: true,
-            keepValues: true,
-        });
-    }, []);
 
     // =========================================================================
     // RENDER FUNCTIONS
@@ -67,12 +51,15 @@ export const BasicDetails = () => {
                             type={field.value}
                             id={element?.id}
                             onChange={(value: EElementType) => {
-                                field.onChange(value);
+                                setValue("type", value, {
+                                    shouldTouch: true,
+                                    shouldDirty: true,
+                                });
+                                setValue("validation", []);
                             }}
                             errorMessage={errors.type?.message}
                         />
                     )}
-                    shouldUnregister={true}
                 />
 
                 {hasProperty("label") && (
@@ -94,7 +81,6 @@ export const BasicDetails = () => {
                                 maxLength={40}
                             />
                         )}
-                        shouldUnregister={true}
                     />
                 )}
 
@@ -112,7 +98,6 @@ export const BasicDetails = () => {
                                 id={element.internalId}
                             />
                         )}
-                        shouldUnregister={true}
                     />
 
                     {watch("required", true) && (
@@ -132,7 +117,6 @@ export const BasicDetails = () => {
                                     }
                                 />
                             )}
-                            shouldUnregister={true}
                         />
                     )}
                 </MandatoryFieldBox>
@@ -160,7 +144,6 @@ export const BasicDetails = () => {
                             errorMessage={errors.id?.message}
                         />
                     )}
-                    shouldUnregister={true}
                 />
 
                 {element?.hasOwnProperty("placeholder") && (
@@ -179,7 +162,6 @@ export const BasicDetails = () => {
                                 errorMessage={errors.placeholder?.message}
                             />
                         )}
-                        shouldUnregister={true}
                     />
                 )}
             </Wrapper>

--- a/src/components/element-editor/conditional-rendering/conditional-rendering-child.tsx
+++ b/src/components/element-editor/conditional-rendering/conditional-rendering-child.tsx
@@ -120,7 +120,6 @@ export const ConditionalRenderingChild = ({
                                     />
                                 );
                             }}
-                            shouldUnregister={true}
                         />
                     </div>
                     <div>
@@ -148,7 +147,6 @@ export const ConditionalRenderingChild = ({
                                     />
                                 );
                             }}
-                            shouldUnregister={true}
                         />
                     </div>
                 </SelectFieldContainer>
@@ -177,7 +175,6 @@ export const ConditionalRenderingChild = ({
                                 />
                             );
                         }}
-                        shouldUnregister={true}
                     />
                 </div>
             </FieldWrapper>

--- a/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
+++ b/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
@@ -31,8 +31,6 @@ export const ConditionalRendering = () => {
     const element = focusedElement?.element;
     const schema = SchemaHelper.buildSchema(EElementType.EMAIL);
     const conditionalRenderingValues = watch("conditionalRendering");
-    const invalidAndEmptyFields = checkIsValid();
-
     // =====================================================================
     // HELPER FUNCTIONS
     // =====================================================================
@@ -52,7 +50,7 @@ export const ConditionalRendering = () => {
         return options;
     };
 
-    function checkIsValid() {
+    const hasInvalidAndEmptyFields = () => {
         try {
             const validationSchema = schema.pick(["conditionalRendering"]);
             validationSchema.validateSync({
@@ -63,21 +61,22 @@ export const ConditionalRendering = () => {
         } catch (error) {
             return Yup.ValidationError.isError(error);
         }
-    }
+    };
 
     const getPopoverMessage = useCallback(() => {
-        if (invalidAndEmptyFields) {
+        if (hasInvalidAndEmptyFields()) {
             return (
                 <Text.Body>
                     To add a new condition, fill up the existing condition
                     first.
                 </Text.Body>
             );
-        } else if (getElementOptions()?.length === 0) {
+        }
+        if (getElementOptions()?.length === 0) {
             return <Text.Body>No conditional rendering available.</Text.Body>;
         }
         return null;
-    }, [invalidAndEmptyFields, getElementOptions]);
+    }, [hasInvalidAndEmptyFields, getElementOptions]);
     // =============================================================================
     // EVENT HANDLERS
     // ============================================================================
@@ -116,7 +115,7 @@ export const ConditionalRendering = () => {
             title="Conditional Rendering"
             buttonLabel="condition"
             disabledButton={
-                getElementOptions().length === 0 || invalidAndEmptyFields
+                getElementOptions().length === 0 || hasInvalidAndEmptyFields()
             }
             popoverMessage={getPopoverMessage()}
         >

--- a/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
+++ b/src/components/element-editor/conditional-rendering/conditional-rendering.tsx
@@ -25,6 +25,7 @@ export const ConditionalRendering = () => {
     const { fields, append, remove } = useFieldArray({
         control,
         name: "conditionalRendering",
+        shouldUnregister: true,
     });
     const { focusedElement, elements } = useBuilder();
     const element = focusedElement?.element;

--- a/src/components/element-editor/element-editor.tsx
+++ b/src/components/element-editor/element-editor.tsx
@@ -8,32 +8,40 @@ import {
 } from "./element-editor.styles";
 import { Prefill } from "./prefill";
 import { Validation } from "./validation/validation";
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { IBaseTextBasedFieldValues } from "src/schemas";
 
 export const ElementEditor = () => {
     // =========================================================================
     // CONST, STATE, REF
     // =========================================================================
-    const { focusedElement } = useBuilder();
+    const { focusedElement, updateFocusedElement } = useBuilder();
 
-    // =============================================================================
-    // RENDER FUNCTIONS
-    // =============================================================================
+    const {
+        formState: { isDirty },
+        getFieldState,
+        getValues,
+    } = useFormContext<IBaseTextBasedFieldValues>();
 
-    const renderAlert = () => {
-        if (!focusedElement.isDirty) {
-            return <></>;
-        } else {
-            return (
-                <SaveChangesAlert type="warning" showIcon>
-                    To reflect changes on preview, save changes first.
-                </SaveChangesAlert>
-            );
+    const { isTouched: isTypeTouched } = getFieldState("type");
+
+    useEffect(() => {
+        // Once the element type is touched, that element should be considered dirty until it is saved or its changes are discarded.
+        if (isTypeTouched) {
+            updateFocusedElement(true);
+            return;
         }
-    };
+        updateFocusedElement(!!isDirty);
+    }, [isDirty, updateFocusedElement]);
 
     return (
         <Wrapper>
-            {renderAlert()}
+            {focusedElement.isDirty && (
+                <SaveChangesAlert type="warning" showIcon>
+                    To reflect changes on preview, save changes first.
+                </SaveChangesAlert>
+            )}
             <AccordionWrapper>
                 <BasicDetails />
             </AccordionWrapper>

--- a/src/components/element-editor/element-editor.tsx
+++ b/src/components/element-editor/element-editor.tsx
@@ -1,4 +1,7 @@
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
 import { useBuilder } from "src/context-providers";
+import { IBaseTextBasedFieldValues } from "src/schemas";
 import { BasicDetails } from "./basic-details";
 import { ConditionalRendering } from "./conditional-rendering";
 import {
@@ -8,9 +11,6 @@ import {
 } from "./element-editor.styles";
 import { Prefill } from "./prefill";
 import { Validation } from "./validation/validation";
-import { useEffect } from "react";
-import { useFormContext } from "react-hook-form";
-import { IBaseTextBasedFieldValues } from "src/schemas";
 
 export const ElementEditor = () => {
     // =========================================================================
@@ -25,6 +25,10 @@ export const ElementEditor = () => {
 
     const { isTouched: isTypeTouched } = getFieldState("type");
 
+    // =========================================================================
+    // EFFECTS
+    // =========================================================================
+
     useEffect(() => {
         // Once the element type is touched, that element should be considered dirty until it is saved or its changes are discarded.
         if (isTypeTouched) {
@@ -33,6 +37,10 @@ export const ElementEditor = () => {
         }
         updateFocusedElement(!!isDirty);
     }, [isDirty, updateFocusedElement]);
+
+    // =========================================================================
+    // RENDER FUNCTIONS
+    // =========================================================================
 
     return (
         <Wrapper data-testid="element-editor">

--- a/src/components/element-editor/element-editor.tsx
+++ b/src/components/element-editor/element-editor.tsx
@@ -21,7 +21,6 @@ export const ElementEditor = () => {
     const {
         formState: { isDirty },
         getFieldState,
-        getValues,
     } = useFormContext<IBaseTextBasedFieldValues>();
 
     const { isTouched: isTypeTouched } = getFieldState("type");

--- a/src/components/element-editor/prefill/prefill-child.tsx
+++ b/src/components/element-editor/prefill/prefill-child.tsx
@@ -51,7 +51,6 @@ export const PrefillChild = ({ onDelete, index }: IProps) => {
                                 />
                             );
                         }}
-                        shouldUnregister={true}
                     />
                 </div>
                 {watch(`prefill.${index}.prefillMode`) ===
@@ -79,7 +78,6 @@ export const PrefillChild = ({ onDelete, index }: IProps) => {
                                     />
                                 );
                             }}
-                            shouldUnregister={true}
                         />
                     </div>
                 )}
@@ -106,7 +104,6 @@ export const PrefillChild = ({ onDelete, index }: IProps) => {
                                 />
                             );
                         }}
-                        shouldUnregister={true}
                     />
                 </div>
             </FieldWrapper>

--- a/src/components/element-editor/prefill/prefill.tsx
+++ b/src/components/element-editor/prefill/prefill.tsx
@@ -9,11 +9,11 @@ export const Prefill = () => {
     // =========================================================================
     // CONST, STATES, REFS
     // =========================================================================
-    const { watch, control } =
-        useFormContext<IBaseTextBasedFieldValues>();
+    const { watch, control } = useFormContext<IBaseTextBasedFieldValues>();
     const { fields, append, remove } = useFieldArray({
         control,
         name: "prefill",
+        shouldUnregister: true,
     });
     const prefillValues = watch("prefill");
     const schema = SchemaHelper.buildSchema(EElementType.EMAIL);

--- a/src/components/element-editor/prefill/prefill.tsx
+++ b/src/components/element-editor/prefill/prefill.tsx
@@ -17,12 +17,11 @@ export const Prefill = () => {
     });
     const prefillValues = watch("prefill");
     const schema = SchemaHelper.buildSchema(EElementType.EMAIL);
-    const invalidAndEmptyFields = checkIsValid();
 
     // =========================================================================
     // HELPER FUNCTIONS
     // =========================================================================
-    function checkIsValid() {
+    const hasInvalidAndEmptyFields = () => {
         try {
             const validationSchema = schema.pick(["prefill"]);
             validationSchema.validateSync({
@@ -33,17 +32,17 @@ export const Prefill = () => {
         } catch (error) {
             return Yup.ValidationError.isError(error);
         }
-    }
+    };
 
-    function getPopoverMessage() {
-        if (invalidAndEmptyFields) {
+    const getPopoverMessage = () => {
+        if (hasInvalidAndEmptyFields()) {
             return (
                 <Text.Body>
                     To add new prefill, fill up existing prefill first.
                 </Text.Body>
             );
         }
-    }
+    };
 
     // =========================================================================
     // EVENT HANDLERS
@@ -85,7 +84,7 @@ export const Prefill = () => {
             title="Prefill"
             buttonLabel="prefill"
             subtitle="Prefill information from various data sources, for example Myinfo."
-            disabledButton={invalidAndEmptyFields}
+            disabledButton={hasInvalidAndEmptyFields()}
             popoverMessage={getPopoverMessage()}
         >
             {renderChildren()}

--- a/src/components/element-editor/validation/validation-child.tsx
+++ b/src/components/element-editor/validation/validation-child.tsx
@@ -61,7 +61,6 @@ export const ValidationChild = ({ onDelete, options, index }: IProps) => {
                                 />
                             );
                         }}
-                        shouldUnregister={true}
                     />
                 </div>
                 <div>
@@ -91,7 +90,6 @@ export const ValidationChild = ({ onDelete, options, index }: IProps) => {
                                 />
                             );
                         }}
-                        shouldUnregister={true}
                     />
                 </div>
                 <div>
@@ -115,7 +113,6 @@ export const ValidationChild = ({ onDelete, options, index }: IProps) => {
                                 />
                             );
                         }}
-                        shouldUnregister={true}
                     />
                 </div>
             </FieldWrapper>

--- a/src/components/element-editor/validation/validation.tsx
+++ b/src/components/element-editor/validation/validation.tsx
@@ -44,7 +44,7 @@ export const Validation = () => {
         }
     };
 
-    const checkIsValid = () => {
+    const hasInvalidAndEmptyfields = () => {
         try {
             const validationSchema = schema.pick(["validation"]);
             validationSchema.validateSync({
@@ -58,8 +58,7 @@ export const Validation = () => {
     };
 
     const getPopoverMessage = () => {
-        const invalidAndEmptyFields = checkIsValid();
-        if (invalidAndEmptyFields) {
+        if (hasInvalidAndEmptyfields()) {
             return (
                 <Text.Body>
                     To add new validation, fill up existing validation first.
@@ -126,7 +125,9 @@ export const Validation = () => {
             onAdd={handleAddButtonClick}
             title="Validation"
             buttonLabel="validation"
-            disabledButton={hasReachedMaxEntries(elementType) || checkIsValid()}
+            disabledButton={
+                hasReachedMaxEntries(elementType) || hasInvalidAndEmptyfields()
+            }
             popoverMessage={getPopoverMessage()}
         >
             {renderChildren()}

--- a/src/components/element-editor/validation/validation.tsx
+++ b/src/components/element-editor/validation/validation.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@lifesg/react-design-system/text";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { MultiEntry } from "src/components/common";
-import { EElementType } from "src/context-providers";
+import { EElementType, useBuilder } from "src/context-providers";
 import { ELEMENT_VALIDATION_TYPES } from "src/data";
 import { IBaseTextBasedFieldValues, SchemaHelper } from "src/schemas";
 import * as Yup from "yup";
@@ -11,6 +11,7 @@ export const Validation = () => {
     // =========================================================================
     // CONST, STATES, REFS
     // =========================================================================
+    const { focusedElement } = useBuilder();
     const { watch, control } = useFormContext<IBaseTextBasedFieldValues>();
     const { fields, append, remove } = useFieldArray({
         control,
@@ -18,8 +19,8 @@ export const Validation = () => {
         shouldUnregister: true,
     });
     const schema = SchemaHelper.buildSchema(EElementType.EMAIL);
-    const validationValues = watch("validation");
-    const elementType = watch("type");
+    const validationValues = watch("validation", focusedElement.element.validation);
+    const elementType = watch("type", focusedElement.element.type);
     const invalidAndEmptyFields = checkIsValid();
 
     // =========================================================================

--- a/src/components/element-editor/validation/validation.tsx
+++ b/src/components/element-editor/validation/validation.tsx
@@ -44,7 +44,7 @@ export const Validation = () => {
         }
     };
 
-    const hasInvalidAndEmptyfields = () => {
+    const hasInvalidAndEmptyFields = () => {
         try {
             const validationSchema = schema.pick(["validation"]);
             validationSchema.validateSync({
@@ -58,7 +58,7 @@ export const Validation = () => {
     };
 
     const getPopoverMessage = () => {
-        if (hasInvalidAndEmptyfields()) {
+        if (hasInvalidAndEmptyFields()) {
             return (
                 <Text.Body>
                     To add new validation, fill up existing validation first.
@@ -126,7 +126,7 @@ export const Validation = () => {
             title="Validation"
             buttonLabel="validation"
             disabledButton={
-                hasReachedMaxEntries(elementType) || hasInvalidAndEmptyfields()
+                hasReachedMaxEntries(elementType) || hasInvalidAndEmptyFields()
             }
             popoverMessage={getPopoverMessage()}
         >

--- a/src/components/element-editor/validation/validation.tsx
+++ b/src/components/element-editor/validation/validation.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@lifesg/react-design-system";
+import { Text } from "@lifesg/react-design-system/text";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { MultiEntry } from "src/components/common";
 import { EElementType } from "src/context-providers";
@@ -15,6 +15,7 @@ export const Validation = () => {
     const { fields, append, remove } = useFieldArray({
         control,
         name: "validation",
+        shouldUnregister: true,
     });
     const schema = SchemaHelper.buildSchema(EElementType.EMAIL);
     const validationValues = watch("validation");

--- a/src/components/side-panel/side-panel-header.tsx
+++ b/src/components/side-panel/side-panel-header.tsx
@@ -1,6 +1,5 @@
 import { Color } from "@lifesg/react-design-system/color";
 import { CrossIcon } from "@lifesg/react-icons/cross";
-import { useFormContext } from "react-hook-form";
 import { useModal } from "src/context-providers/display/modal-hook";
 import { EBuilderMode, EModalType, useBuilder } from "../../context-providers";
 import { IconButton } from "../common";

--- a/src/components/side-panel/side-panel-header.tsx
+++ b/src/components/side-panel/side-panel-header.tsx
@@ -12,7 +12,7 @@ import {
 import { useFormContext } from "react-hook-form";
 
 interface IProps {
-    isSubmitting: boolean;
+    isSubmitting?: boolean;
 }
 
 export const SidePanelHeader = ({ isSubmitting }: IProps) => {

--- a/src/components/side-panel/side-panel-header.tsx
+++ b/src/components/side-panel/side-panel-header.tsx
@@ -1,5 +1,6 @@
 import { Color } from "@lifesg/react-design-system/color";
 import { CrossIcon } from "@lifesg/react-icons/cross";
+import { useFormContext } from "react-hook-form";
 import { useModal } from "src/context-providers/display/modal-hook";
 import { EBuilderMode, EModalType, useBuilder } from "../../context-providers";
 import { IconButton } from "../common";

--- a/src/components/side-panel/side-panel-header.tsx
+++ b/src/components/side-panel/side-panel-header.tsx
@@ -9,6 +9,7 @@ import {
     SaveChangesButton,
     Wrapper,
 } from "./side-panel-header.styles";
+import { useFormContext } from "react-hook-form";
 
 interface IProps {
     isSubmitting: boolean;
@@ -27,6 +28,7 @@ export const SidePanelHeader = ({ isSubmitting }: IProps) => {
     } = useBuilder();
     const { isDirty } = focusedElement || {};
     const { showModal, discardChanges } = useModal();
+    const { reset } = useFormContext();
     // =========================================================================
     // HELPER FUNCTIONS
     // =========================================================================
@@ -46,6 +48,7 @@ export const SidePanelHeader = ({ isSubmitting }: IProps) => {
     const handleModalOnClick = () => {
         removeFocusedElement();
         discardChanges();
+        reset();
     };
 
     // =========================================================================

--- a/src/components/side-panel/side-panel.tsx
+++ b/src/components/side-panel/side-panel.tsx
@@ -1,7 +1,12 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useCallback, useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { EElementType, EToastTypes, TElement, useDisplay } from "src/context-providers";
+import {
+    EElementType,
+    EToastTypes,
+    TElement,
+    useDisplay,
+} from "src/context-providers";
 import { SchemaHelper } from "src/schemas";
 import { EBuilderMode, useBuilder } from "../../context-providers";
 import { ElementEditor } from "../element-editor";
@@ -31,12 +36,7 @@ export const SidePanel = ({ offset, onSubmit }: IProps) => {
     const methods = useForm({
         mode: "onTouched",
         defaultValues: {
-            type: "",
-            label: "",
-            required: true,
             requiredErrorMsg: "",
-            id: "",
-            placeholder: "",
         },
         // TODO: insert proper type; email is a placeholder
         resolver: yupResolver(SchemaHelper.buildSchema(EElementType.EMAIL)),

--- a/src/components/side-panel/side-panel.tsx
+++ b/src/components/side-panel/side-panel.tsx
@@ -28,9 +28,21 @@ export const SidePanel = ({ offset }: IProps) => {
     const { showToast } = useDisplay();
     const methods = useForm({
         mode: "onTouched",
+        defaultValues: {
+            type: "",
+            label: "",
+            required: true,
+            requiredErrorMsg: "",
+            id: "",
+            placeholder: "",
+        },
         // TODO: insert proper type; email is a placeholder
         resolver: yupResolver(SchemaHelper.buildSchema(EElementType.EMAIL)),
     });
+
+    const {
+        formState: { isSubmitSuccessful, isSubmitting },
+    } = methods;
 
     // =========================================================================
     // HELPER FUNCTIONS
@@ -50,21 +62,21 @@ export const SidePanel = ({ offset }: IProps) => {
     // =========================================================================
     // USE EFFECTS
     // =========================================================================
-    useEffect(() => {
-        methods.reset(undefined, {
-            keepValues: true,
-            keepDirty: false,
-        });
-    }, [methods.formState.isSubmitSuccessful]);
 
     useEffect(() => {
-        if (focusedElement) {
-            const newElement = {};
-            Object.entries(focusedElement?.element).forEach(([key, value]) => {
-                newElement[key] = value === undefined ? "" : value;
+        if (isSubmitSuccessful) {
+            methods.reset(undefined, {
+                keepValues: true,
+                keepDirty: false,
             });
-            methods.reset(newElement);
         }
+    }, [isSubmitSuccessful, methods.reset]);
+
+    useEffect(() => {
+        if (!focusedElement || isSubmitting) {
+            return;
+        }
+        methods.reset(focusedElement.element);
     }, [focusedElement?.element, methods.reset]);
 
     // =========================================================================
@@ -75,7 +87,6 @@ export const SidePanel = ({ offset }: IProps) => {
         if (focusedElement) {
             return <ElementEditor />;
         }
-
         switch (currentMode) {
             case EBuilderMode.ADD_ELEMENT:
                 return <AddElementsPanel />;

--- a/src/components/side-panel/side-panel.tsx
+++ b/src/components/side-panel/side-panel.tsx
@@ -41,7 +41,7 @@ export const SidePanel = ({ offset }: IProps) => {
     });
 
     const {
-        formState: { isSubmitSuccessful, isSubmitting },
+        formState: { isSubmitSuccessful },
     } = methods;
 
     // =========================================================================
@@ -65,15 +65,16 @@ export const SidePanel = ({ offset }: IProps) => {
 
     useEffect(() => {
         if (isSubmitSuccessful) {
-            methods.reset(undefined, {
-                keepValues: true,
-                keepDirty: false,
-            });
+            /**
+             * On React 17, without setTimeout, isSubmitSuccessful is set to true again on first touch of the form after resetting form.
+             * This issue is fixed on React 18, but the workaround on React 17 would be to use setTimeout.
+             */
+            setTimeout(() => methods.reset());
         }
     }, [isSubmitSuccessful, methods.reset]);
 
     useEffect(() => {
-        if (!focusedElement || isSubmitting) {
+        if (!focusedElement) {
             return;
         }
         methods.reset(focusedElement.element);

--- a/src/context-providers/builder/provider.tsx
+++ b/src/context-providers/builder/provider.tsx
@@ -60,7 +60,6 @@ export const builderReducer = (
             break;
         }
         case "remove-focused-element": {
-            state.focusedElement.isDirty = false;
             state.focusedElement = null;
             break;
         }

--- a/src/context-providers/builder/provider.tsx
+++ b/src/context-providers/builder/provider.tsx
@@ -55,6 +55,7 @@ export const builderReducer = (
             break;
         }
         case "remove-focused-element": {
+            state.focusedElement.isDirty = false;
             state.focusedElement = null;
             break;
         }

--- a/src/util/test-helper.tsx
+++ b/src/util/test-helper.tsx
@@ -16,6 +16,8 @@ const mockBuilderState: IBuilderState = {
     focusedElement: null,
     showSidePanel: true,
     orderedIdentifiers: [],
+    deletedElements: {},
+    elementCounter: 0,
 };
 
 const mockDisplayState: IDisplayState = {

--- a/tests/components/element-editor/validation/validation.spec.tsx
+++ b/tests/components/element-editor/validation/validation.spec.tsx
@@ -23,13 +23,13 @@ describe("Validation", () => {
         jest.resetAllMocks();
     });
 
-    it("should contain the the component with the title, buttonLabel & children being passed into it", () => {
+    it("should contain the component with the title, buttonLabel & children being passed into it", () => {
         renderComponent(EElementType.EMAIL, {
             builderContext: {
                 focusedElement: { element: MOCK_ELEMENT, isDirty: true },
             },
         });
-        expect(screen.getByText("Validation")).toBeInTheDocument();
+        expect(screen.getByText("Additional Validation")).toBeInTheDocument();
         expect(getAddValidationButton()).toBeInTheDocument();
     });
 

--- a/tests/components/side-panel/side-panel-header.spec.tsx
+++ b/tests/components/side-panel/side-panel-header.spec.tsx
@@ -1,5 +1,7 @@
+import { yupResolver } from "@hookform/resolvers/yup";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "jest-canvas-mock";
+import { FormProvider, useForm } from "react-hook-form";
 import { Modals } from "src/components";
 import { SidePanelHeader } from "src/components/side-panel/side-panel-header";
 import {
@@ -8,6 +10,7 @@ import {
     EElementType,
 } from "src/context-providers";
 import { ELEMENT_BUTTON_LABELS } from "src/data/elements-data";
+import { SchemaHelper } from "src/schemas";
 import { TestHelper } from "src/util/test-helper";
 
 describe("SidePanelHeader", () => {
@@ -99,16 +102,25 @@ describe("SidePanelHeader", () => {
 // HELPER FUNCTIONS
 // =============================================================================
 
-const renderComponent = (overrideOptions?: TestHelper.RenderOptions) => {
-    return render(
-        TestHelper.withProviders(
-            overrideOptions,
-            <DisplayProvider>
-                <Modals />
-                <SidePanelHeader />
-            </DisplayProvider>
-        )
+const TestComponent = () => {
+    const methods = useForm({
+        mode: "onTouched",
+        resolver: yupResolver(SchemaHelper.buildSchema(EElementType.EMAIL)),
+    });
+    return (
+        <DisplayProvider>
+            <Modals />
+            <FormProvider {...methods}>
+                <form>
+                    <SidePanelHeader />
+                </form>
+            </FormProvider>
+        </DisplayProvider>
     );
+};
+
+const renderComponent = (overrideOptions?: TestHelper.RenderOptions) => {
+    return render(TestHelper.withProviders(overrideOptions, <TestComponent />));
 };
 
 const getHeaderLabel = () => screen.getByTestId("header-label");
@@ -126,4 +138,5 @@ const mockElement = {
     id: "mockElement",
     required: false,
     label: ELEMENT_BUTTON_LABELS[EElementType.EMAIL],
+    columns: { desktop: 12, tablet: 8, mobile: 4 } as const,
 };


### PR DESCRIPTION
This PR contains commits for both CCUBE-1480 and CCUBE-1466

**Changes**

**CCUBE-1480**
- Refactor validation, conditional rendering and prefill to use `useFieldArray`
  - Remove need for `useEffect`/`useState`
  - Replace custom remove/add logic with built in `remove` and `append`
  - Remove shouldUnregister since not recommended for useFieldArray
- Shift cross-cutting logic of form to element editor
- Update element to clean state when unfocused
- Add default values to `useForm`
- Edit form reset logic upon submission
- Add `shouldUnregister` to all fields
- Add `setTimeout` to `reset()`

**CCUBE-1466**
- Show correct validation types based on element type
- Mark form as dirty and clear validation once element type is touched
- Add default values to watch to fix failing test cases



**Additional information**

-   You may refer to [CCUBE-1466](https://jira.ship.gov.sg/browse/CCUBE-1466) and [CCUBE-1480](https://jira.ship.gov.sg/browse/CCUBE-1480)
