### PR TITLE
[CCUBE-1435][SR] Amended updateElements hook bug that causes the translator story to crash

### DIFF
--- a/src/context-providers/builder/hook.ts
+++ b/src/context-providers/builder/hook.ts
@@ -286,16 +286,18 @@ export const useBuilder = () => {
                 },
             });
 
-            dispatch({
-                type: "remove-focused-element",
-            });
+            if (newFocusedElement) {
+                dispatch({
+                    type: "remove-focused-element",
+                });
 
-            dispatch({
-                type: "focus-element",
-                payload: {
-                    element: newFocusedElement,
-                },
-            });
+                dispatch({
+                    type: "focus-element",
+                    payload: {
+                        element: newFocusedElement,
+                    },
+                });
+            }
         },
         []
     );


### PR DESCRIPTION
**Changes**

- Amended the hook to conditionally run the focused elements hooks if the newFocusedElement is provided.

**Additional information**

-   You may refer to this [CCUBE-1435](https://jira.ship.gov.sg/browse/CCUBE-1435)
-   This was identified when I was testing the dev env for deskchecking CCUBE-1435, realised that when providing a field in schema view when elements are not in focus in the formbuilder, causes the story to crash as it is updating focused element as undefined.
