### PR TITLE
[CCUBE-1435][SR] Amended bug when parsing element from schema view due to no size being given

### DIFF
--- a/src/translator/helper.ts
+++ b/src/translator/helper.ts
@@ -143,7 +143,10 @@ export const updateParsedElements = (parsedElements: TElement[]) => {
 
     Object.values(parsedElements).forEach((parsedElement: TElement) => {
         newElements[parsedElement.internalId] = parsedElement;
-        newOrderedIdentifiers.push({ internalId: parsedElement.internalId });
+        newOrderedIdentifiers.push({
+            internalId: parsedElement.internalId,
+            size: "full",
+        });
 
         if (parsedElement?.conditionalRendering?.length > 0) {
             parsedElement.conditionalRendering.forEach((condition, index) => {


### PR DESCRIPTION
**Changes**
- Added the size when parsing elements so the story won't crash, when rendering the element card.

**Additional information**

-   You may refer to this [CCUBE-1435](https://jira.ship.gov.sg/browse/CCUBE-1435)
-   This bug was found when doing deskcheck and caused the story to crash as the size of the card was not given when parsing the elements from schema view to form builder.
