### PR TITLE
CCUBE-1512-2

### DIFF
--- a/src/components/element-editor/validation/validation.tsx
+++ b/src/components/element-editor/validation/validation.tsx
@@ -92,8 +92,6 @@ export const Validation = () => {
             case EElementType.TEXTAREA:
                 return ELEMENT_VALIDATION_TYPES["Text field"][elementType]
                     .validationTypes[0];
-            default:
-                return "";
         }
     };
 

--- a/src/translator/generate/common/generate-base-schema.ts
+++ b/src/translator/generate/common/generate-base-schema.ts
@@ -19,9 +19,6 @@ export const generateBaseSchema = (element: TElement) => {
             tablet: element.columns.tablet,
             mobile: element.columns.mobile,
         },
-        ...(element.placeholder && {
-            placeholder: element.placeholder,
-        }),
         ...(element.required && {
             validation: [
                 {

--- a/src/translator/generate/elements/contact/contact-schema-generator.ts
+++ b/src/translator/generate/elements/contact/contact-schema-generator.ts
@@ -8,6 +8,9 @@ export namespace ContactSchemaGenerator {
         const contactSchema = {
             [element.id]: {
                 ...baseSchema,
+                ...(element.placeholder && {
+                    placeholder: element.placeholder,
+                }),
                 // Add additional validation if it exists
                 // ...(additionalValidationSchema && {
                 //     validation: [

--- a/src/translator/generate/elements/dropdown/dropdown-schema-generator.ts
+++ b/src/translator/generate/elements/dropdown/dropdown-schema-generator.ts
@@ -11,6 +11,9 @@ export namespace DropdownSchemaGenerator {
         const dropdownSchema = {
             [element.id]: {
                 ...baseSchema,
+                ...(element.placeholder && {
+                    placeholder: element.placeholder,
+                }),
                 ...(filteredDropdownItems && {
                     options: filteredDropdownItems,
                 }),

--- a/src/translator/generate/elements/email/email-schema-generator.ts
+++ b/src/translator/generate/elements/email/email-schema-generator.ts
@@ -31,6 +31,9 @@ export namespace EmailSchemaGenerator {
         const emailSchema = {
             [element.id]: {
                 ...baseSchema,
+                ...(element.placeholder && {
+                    placeholder: element.placeholder,
+                }),
                 // Add additional validation if it exists
                 ...(additionalValidationSchema && {
                     validation: [

--- a/src/translator/generate/elements/long-text/long-text-schema-generator.ts
+++ b/src/translator/generate/elements/long-text/long-text-schema-generator.ts
@@ -19,6 +19,9 @@ export namespace LongTextSchemaGenerator {
         const longTextSchema = {
             [element.id]: {
                 ...baseSchema,
+                ...(element.placeholder && {
+                    placeholder: element.placeholder,
+                }),
                 // Add additional validation if it exists
                 ...(additionalValidationSchema && {
                     validation: [

--- a/src/translator/generate/elements/numeric/numeric-schema-generator.ts
+++ b/src/translator/generate/elements/numeric/numeric-schema-generator.ts
@@ -46,6 +46,9 @@ export namespace NumericSchemaGenerator {
         const numericSchema = {
             [element.id]: {
                 ...baseSchema,
+                ...(element.placeholder && {
+                    placeholder: element.placeholder,
+                }),
                 // Add additional validation if it exists
                 ...(additionalValidationSchema && {
                     validation: [

--- a/src/translator/generate/elements/text/text-schema-generator.ts
+++ b/src/translator/generate/elements/text/text-schema-generator.ts
@@ -46,6 +46,9 @@ export namespace TextSchemaGenerator {
         const textSchema = {
             [element.id]: {
                 ...baseSchema,
+                ...(element.placeholder && {
+                    placeholder: element.placeholder,
+                }),
                 // Add additional validation if it exists
                 ...(additionalValidationSchema && {
                     validation: [

--- a/tests/util/translator/generate/common/generate-base-schema.spec.tsx
+++ b/tests/util/translator/generate/common/generate-base-schema.spec.tsx
@@ -17,7 +17,7 @@ describe("GenerateBaseSchema", () => {
     });
 
     it("should generate the full base schema if everything is provided", () => {
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             label,
             description: "This is a description",
@@ -39,7 +39,7 @@ describe("GenerateBaseSchema", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -73,7 +73,7 @@ describe("GenerateBaseSchema", () => {
     });
 
     it("should generate the base schema without placeholder if placeholder is not provided", () => {
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             label,
             description,
@@ -94,7 +94,7 @@ describe("GenerateBaseSchema", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -127,7 +127,7 @@ describe("GenerateBaseSchema", () => {
     });
 
     it("should generate the base schema without showIf if conditional rendering is not provided", () => {
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             label,
             description,
@@ -141,7 +141,7 @@ describe("GenerateBaseSchema", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -163,7 +163,7 @@ describe("GenerateBaseSchema", () => {
     });
 
     it("should generate the base schema without subLabel if description is not provided", () => {
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             label,
             id: elementId,
@@ -184,7 +184,7 @@ describe("GenerateBaseSchema", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -217,7 +217,7 @@ describe("GenerateBaseSchema", () => {
     });
 
     it("should generate the base schema without validation if required and requiredErrorMsg is not provided", () => {
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             label,
             description,
@@ -238,7 +238,7 @@ describe("GenerateBaseSchema", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,

--- a/tests/util/translator/generate/common/generate-base-schema.spec.tsx
+++ b/tests/util/translator/generate/common/generate-base-schema.spec.tsx
@@ -19,13 +19,13 @@ describe("GenerateBaseSchema", () => {
     it("should generate the full base schema if everything is provided", () => {
         const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
-            label,
+            label: LABEL,
             description: "This is a description",
-            id: elementId,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             placeholder: "Enter your text here",
             validation: [],
             conditionalRendering: [
@@ -42,9 +42,9 @@ describe("GenerateBaseSchema", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
                 subLabel: "This is a description",
             },
             placeholder: "Enter your text here",
@@ -52,7 +52,7 @@ describe("GenerateBaseSchema", () => {
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
             ],
             showIf: [
@@ -75,13 +75,13 @@ describe("GenerateBaseSchema", () => {
     it("should generate the base schema without placeholder if placeholder is not provided", () => {
         const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
-            label,
-            description,
-            id: elementId,
+            label: LABEL,
+            description: DESCRIPTION,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             validation: [],
             conditionalRendering: [
                 {
@@ -97,16 +97,16 @@ describe("GenerateBaseSchema", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
-                subLabel: description,
+                mainLabel: LABEL,
+                subLabel: DESCRIPTION,
             },
             uiType: EElementType.TEXT,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
             ],
             showIf: [
@@ -129,13 +129,13 @@ describe("GenerateBaseSchema", () => {
     it("should generate the base schema without showIf if conditional rendering is not provided", () => {
         const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
-            label,
-            description,
-            id: elementId,
+            label: LABEL,
+            description: DESCRIPTION,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             placeholder: "Enter your text here",
             validation: [],
         };
@@ -144,17 +144,17 @@ describe("GenerateBaseSchema", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
-                subLabel: description,
+                mainLabel: LABEL,
+                subLabel: DESCRIPTION,
             },
             placeholder: "Enter your text here",
             uiType: EElementType.TEXT,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
             ],
         });
@@ -165,12 +165,12 @@ describe("GenerateBaseSchema", () => {
     it("should generate the base schema without subLabel if description is not provided", () => {
         const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             placeholder: "Enter your text here",
             validation: [],
             conditionalRendering: [
@@ -187,16 +187,16 @@ describe("GenerateBaseSchema", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             placeholder: "Enter your text here",
             uiType: EElementType.TEXT,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
             ],
             showIf: [
@@ -219,9 +219,9 @@ describe("GenerateBaseSchema", () => {
     it("should generate the base schema without validation if required and requiredErrorMsg is not provided", () => {
         const mockElement: ITextField = {
             columns: { desktop: 12, tablet: 8, mobile: 4 },
-            label,
-            description,
-            id: elementId,
+            label: LABEL,
+            description: DESCRIPTION,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: false,
@@ -241,10 +241,10 @@ describe("GenerateBaseSchema", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
-                subLabel: description,
+                mainLabel: LABEL,
+                subLabel: DESCRIPTION,
             },
             placeholder: "Enter your text here",
             uiType: EElementType.TEXT,
@@ -269,7 +269,7 @@ describe("GenerateBaseSchema", () => {
 // =============================================================================
 // HELPERS
 // =============================================================================
-const elementId = "mockId123";
-const label = "Text Field";
-const description = "This is a description";
-const requiredErrorMsg = "This field is required";
+const ELEMENT_ID = "mockId123";
+const LABEL = "Text Field";
+const DESCRIPTION = "This is a description";
+const REQUIRED_ERROR_MESSAGE = "This field is required";

--- a/tests/util/translator/generate/elements/dropdown/dropdown-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/dropdown/dropdown-schema-generator.spec.tsx
@@ -20,8 +20,8 @@ describe("DropdownSchemaGenerator", () => {
         const placeholder = "This is a placeholder";
 
         const mockElement: IDropdown = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "dropdown-field",
             type: EElementType.DROPDOWN,
             required: false,
@@ -42,7 +42,7 @@ describe("DropdownSchemaGenerator", () => {
         const generatedSchema =
             DropdownSchemaGenerator.elementToSchema(mockElement);
 
-        expect(generatedSchema[elementId]).toHaveProperty(
+        expect(generatedSchema[ELEMENT_ID]).toHaveProperty(
             "placeholder",
             placeholder
         );
@@ -50,8 +50,8 @@ describe("DropdownSchemaGenerator", () => {
 
     it("should generate the base schema with options if dropdown items are added", () => {
         const mockElement: IDropdown = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "dropdown-field",
             type: EElementType.DROPDOWN,
             required: false,
@@ -72,9 +72,9 @@ describe("DropdownSchemaGenerator", () => {
             DropdownSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.DROPDOWN,
             dropdownItems: [
@@ -96,5 +96,5 @@ describe("DropdownSchemaGenerator", () => {
 // =============================================================================
 // HELPERS
 // =============================================================================
-const elementId = "mockId123";
-const label = "dropdown-field";
+const ELEMENT_ID = "mockId123";
+const LABEL = "dropdown-field";

--- a/tests/util/translator/generate/elements/dropdown/dropdown-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/dropdown/dropdown-schema-generator.spec.tsx
@@ -19,7 +19,7 @@ describe("DropdownSchemaGenerator", () => {
     it("should generate the base schema with placeholder if placeholder is added", () => {
         const placeholder = "This is a placeholder";
 
-        const MOCK_ELEMENT: IDropdown = {
+        const mockElement: IDropdown = {
             label,
             id: elementId,
             internalId: "dropdown-field",
@@ -40,7 +40,7 @@ describe("DropdownSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            DropdownSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            DropdownSchemaGenerator.elementToSchema(mockElement);
 
         expect(generatedSchema[elementId]).toHaveProperty(
             "placeholder",
@@ -49,7 +49,7 @@ describe("DropdownSchemaGenerator", () => {
     });
 
     it("should generate the base schema with options if dropdown items are added", () => {
-        const MOCK_ELEMENT: IDropdown = {
+        const mockElement: IDropdown = {
             label,
             id: elementId,
             internalId: "dropdown-field",
@@ -69,7 +69,7 @@ describe("DropdownSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            DropdownSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            DropdownSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,

--- a/tests/util/translator/generate/elements/dropdown/dropdown-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/dropdown/dropdown-schema-generator.spec.tsx
@@ -16,10 +16,39 @@ describe("DropdownSchemaGenerator", () => {
         jest.resetAllMocks();
     });
 
-    it("should generate the base schema with options if dropdown items are added", () => {
-        const elementId = "mockId123";
-        const label = "dropdown-field";
+    it("should generate the base schema with placeholder if placeholder is added", () => {
+        const placeholder = "This is a placeholder";
 
+        const MOCK_ELEMENT: IDropdown = {
+            label,
+            id: elementId,
+            internalId: "dropdown-field",
+            type: EElementType.DROPDOWN,
+            required: false,
+            columns: { desktop: 12, tablet: 8, mobile: 4 },
+            placeholder,
+            dropdownItems: [
+                {
+                    label: "Option 1",
+                    value: "option1",
+                },
+                {
+                    label: "Option 2",
+                    value: "option2",
+                },
+            ],
+        };
+
+        const generatedSchema =
+            DropdownSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+
+        expect(generatedSchema[elementId]).toHaveProperty(
+            "placeholder",
+            placeholder
+        );
+    });
+
+    it("should generate the base schema with options if dropdown items are added", () => {
         const MOCK_ELEMENT: IDropdown = {
             label,
             id: elementId,
@@ -63,3 +92,9 @@ describe("DropdownSchemaGenerator", () => {
         expect(generatedSchema).toStrictEqual(expectedSchema);
     });
 });
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+const elementId = "mockId123";
+const label = "dropdown-field";

--- a/tests/util/translator/generate/elements/email/email-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/email/email-schema-generator.spec.tsx
@@ -24,8 +24,8 @@ describe("EmailSchemaGenerator", () => {
         const placeholder = "This is a placeholder";
 
         const mockElement: IEmailField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "email-field",
             type: EElementType.EMAIL,
             required: false,
@@ -37,7 +37,7 @@ describe("EmailSchemaGenerator", () => {
         const generatedSchema =
             EmailSchemaGenerator.elementToSchema(mockElement);
 
-        expect(generatedSchema[elementId]).toHaveProperty(
+        expect(generatedSchema[ELEMENT_ID]).toHaveProperty(
             "placeholder",
             placeholder
         );
@@ -49,8 +49,8 @@ describe("EmailSchemaGenerator", () => {
             "This field only accepts gmail addresses";
 
         const mockElement: IEmailField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "email-field",
             type: EElementType.EMAIL,
             required: false,
@@ -68,9 +68,9 @@ describe("EmailSchemaGenerator", () => {
             EmailSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.EMAIL,
             validation: [
@@ -90,12 +90,12 @@ describe("EmailSchemaGenerator", () => {
             "This field only accepts gmail addresses";
 
         const mockElement: IEmailField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "numeric-field",
             type: EElementType.EMAIL,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             validation: [
                 {
@@ -110,15 +110,15 @@ describe("EmailSchemaGenerator", () => {
             EmailSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.EMAIL,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
                 {
                     matches: "/^[a-zA-Z0-9._%+-]+@(gmail\\.com)$/",
@@ -135,6 +135,6 @@ describe("EmailSchemaGenerator", () => {
 // HELPERS
 // =============================================================================
 
-const elementId = "mockId123";
-const label = "email-field";
-const requiredErrorMsg = "This field is required";
+const ELEMENT_ID = "mockId123";
+const LABEL = "email-field";
+const REQUIRED_ERROR_MESSAGE = "This field is required";

--- a/tests/util/translator/generate/elements/email/email-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/email/email-schema-generator.spec.tsx
@@ -20,6 +20,29 @@ describe("EmailSchemaGenerator", () => {
         jest.resetAllMocks();
     });
 
+    it("should generate the base schema with placeholder if placeholder is added", () => {
+        const placeholder = "This is a placeholder";
+
+        const MOCK_ELEMENT: IEmailField = {
+            label,
+            id: elementId,
+            internalId: "email-field",
+            type: EElementType.EMAIL,
+            required: false,
+            columns: { desktop: 12, tablet: 8, mobile: 4 },
+            validation: [],
+            placeholder,
+        };
+
+        const generatedSchema =
+            EmailSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+
+        expect(generatedSchema[elementId]).toHaveProperty(
+            "placeholder",
+            placeholder
+        );
+    });
+
     it("should generate the base schema WITH only additional validation if additional validation is added but required is false", () => {
         const validationRule = "@gmail.com";
         const validationErrorMessage =

--- a/tests/util/translator/generate/elements/email/email-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/email/email-schema-generator.spec.tsx
@@ -23,7 +23,7 @@ describe("EmailSchemaGenerator", () => {
     it("should generate the base schema with placeholder if placeholder is added", () => {
         const placeholder = "This is a placeholder";
 
-        const MOCK_ELEMENT: IEmailField = {
+        const mockElement: IEmailField = {
             label,
             id: elementId,
             internalId: "email-field",
@@ -35,7 +35,7 @@ describe("EmailSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            EmailSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            EmailSchemaGenerator.elementToSchema(mockElement);
 
         expect(generatedSchema[elementId]).toHaveProperty(
             "placeholder",
@@ -48,7 +48,7 @@ describe("EmailSchemaGenerator", () => {
         const validationErrorMessage =
             "This field only accepts gmail addresses";
 
-        const MOCK_ELEMENT: IEmailField = {
+        const mockElement: IEmailField = {
             label,
             id: elementId,
             internalId: "email-field",
@@ -65,7 +65,7 @@ describe("EmailSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            EmailSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            EmailSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -89,7 +89,7 @@ describe("EmailSchemaGenerator", () => {
         const validationErrorMessage =
             "This field only accepts gmail addresses";
 
-        const MOCK_ELEMENT: IEmailField = {
+        const mockElement: IEmailField = {
             label,
             id: elementId,
             internalId: "numeric-field",
@@ -107,7 +107,7 @@ describe("EmailSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            EmailSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            EmailSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,

--- a/tests/util/translator/generate/elements/long-text/long-text-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/long-text/long-text-schema-generator.spec.tsx
@@ -23,7 +23,7 @@ describe("LongTextSchemaGenerator", () => {
     it("should generate the base schema with placeholder if placeholder is added", () => {
         const placeholder = "This is a placeholder";
 
-        const MOCK_ELEMENT: ITextarea = {
+        const mockElement: ITextarea = {
             label,
             id: elementId,
             internalId: "long-text-field",
@@ -35,7 +35,7 @@ describe("LongTextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            LongTextSchemaGenerator.elementToSchema(mockElement);
 
         expect(generatedSchema[elementId]).toHaveProperty(
             "placeholder",
@@ -44,7 +44,7 @@ describe("LongTextSchemaGenerator", () => {
     });
 
     it("should generate the base schema WITHOUT validation if required is false", () => {
-        const MOCK_ELEMENT: ITextarea = {
+        const mockElement: ITextarea = {
             label,
             id: elementId,
             internalId: "long-text-field",
@@ -55,7 +55,7 @@ describe("LongTextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -69,7 +69,7 @@ describe("LongTextSchemaGenerator", () => {
     });
 
     it("should generate the base schema WITH validation if required is true", () => {
-        const MOCK_ELEMENT: ITextarea = {
+        const mockElement: ITextarea = {
             label,
             id: elementId,
             internalId: "long-text-field",
@@ -81,7 +81,7 @@ describe("LongTextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -105,7 +105,7 @@ describe("LongTextSchemaGenerator", () => {
         const validationErrorMessage =
             "This field must be at most 5 characters long";
 
-        const MOCK_ELEMENT: ITextarea = {
+        const mockElement: ITextarea = {
             label,
             id: elementId,
             internalId: "long-text-field",
@@ -122,7 +122,7 @@ describe("LongTextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -146,7 +146,7 @@ describe("LongTextSchemaGenerator", () => {
         const validationMaxErrorMessage =
             "This field must be at most 10 characters long";
 
-        const MOCK_ELEMENT: ITextarea = {
+        const mockElement: ITextarea = {
             label,
             id: elementId,
             internalId: "text-field",
@@ -164,7 +164,7 @@ describe("LongTextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -189,7 +189,7 @@ describe("LongTextSchemaGenerator", () => {
     });
 
     it("should generate the schema with conditional rendering if conditional rendering is added", () => {
-        const MOCK_ELEMENT: ITextarea = {
+        const mockElement: ITextarea = {
             label,
             id: elementId,
             internalId: "long-text-field",
@@ -208,7 +208,7 @@ describe("LongTextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,

--- a/tests/util/translator/generate/elements/long-text/long-text-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/long-text/long-text-schema-generator.spec.tsx
@@ -20,6 +20,29 @@ describe("LongTextSchemaGenerator", () => {
         jest.resetAllMocks();
     });
 
+    it("should generate the base schema with placeholder if placeholder is added", () => {
+        const placeholder = "This is a placeholder";
+
+        const MOCK_ELEMENT: ITextarea = {
+            label,
+            id: elementId,
+            internalId: "long-text-field",
+            type: EElementType.TEXTAREA,
+            required: false,
+            columns: { desktop: 12, tablet: 8, mobile: 4 },
+            validation: [],
+            placeholder,
+        };
+
+        const generatedSchema =
+            LongTextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+
+        expect(generatedSchema[elementId]).toHaveProperty(
+            "placeholder",
+            placeholder
+        );
+    });
+
     it("should generate the base schema WITHOUT validation if required is false", () => {
         const MOCK_ELEMENT: ITextarea = {
             label,

--- a/tests/util/translator/generate/elements/long-text/long-text-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/long-text/long-text-schema-generator.spec.tsx
@@ -24,8 +24,8 @@ describe("LongTextSchemaGenerator", () => {
         const placeholder = "This is a placeholder";
 
         const mockElement: ITextarea = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "long-text-field",
             type: EElementType.TEXTAREA,
             required: false,
@@ -37,7 +37,7 @@ describe("LongTextSchemaGenerator", () => {
         const generatedSchema =
             LongTextSchemaGenerator.elementToSchema(mockElement);
 
-        expect(generatedSchema[elementId]).toHaveProperty(
+        expect(generatedSchema[ELEMENT_ID]).toHaveProperty(
             "placeholder",
             placeholder
         );
@@ -45,8 +45,8 @@ describe("LongTextSchemaGenerator", () => {
 
     it("should generate the base schema WITHOUT validation if required is false", () => {
         const mockElement: ITextarea = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "long-text-field",
             type: EElementType.TEXTAREA,
             required: false,
@@ -58,9 +58,9 @@ describe("LongTextSchemaGenerator", () => {
             LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXTAREA,
         });
@@ -70,12 +70,12 @@ describe("LongTextSchemaGenerator", () => {
 
     it("should generate the base schema WITH validation if required is true", () => {
         const mockElement: ITextarea = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "long-text-field",
             type: EElementType.TEXTAREA,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             validation: [],
         };
@@ -84,15 +84,15 @@ describe("LongTextSchemaGenerator", () => {
             LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXTAREA,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
             ],
         });
@@ -106,8 +106,8 @@ describe("LongTextSchemaGenerator", () => {
             "This field must be at most 5 characters long";
 
         const mockElement: ITextarea = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "long-text-field",
             type: EElementType.TEXTAREA,
             required: false,
@@ -125,9 +125,9 @@ describe("LongTextSchemaGenerator", () => {
             LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXTAREA,
             validation: [
@@ -147,12 +147,12 @@ describe("LongTextSchemaGenerator", () => {
             "This field must be at most 10 characters long";
 
         const mockElement: ITextarea = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXTAREA,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             validation: [
                 {
@@ -167,15 +167,15 @@ describe("LongTextSchemaGenerator", () => {
             LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXTAREA,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
 
                 {
@@ -190,8 +190,8 @@ describe("LongTextSchemaGenerator", () => {
 
     it("should generate the schema with conditional rendering if conditional rendering is added", () => {
         const mockElement: ITextarea = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "long-text-field",
             type: EElementType.TEXTAREA,
             required: false,
@@ -211,9 +211,9 @@ describe("LongTextSchemaGenerator", () => {
             LongTextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXTAREA,
             showIf: [
@@ -238,6 +238,6 @@ describe("LongTextSchemaGenerator", () => {
 // HELPERS
 // =============================================================================
 
-const elementId = "mockId123";
-const label = "Long text";
-const requiredErrorMsg = "This field is required";
+const ELEMENT_ID = "mockId123";
+const LABEL = "Long text";
+const REQUIRED_ERROR_MESSAGE = "This field is required";

--- a/tests/util/translator/generate/elements/numeric/numeric-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/numeric/numeric-schema-generator.spec.tsx
@@ -23,7 +23,7 @@ describe("NumericSchemaGenerator", () => {
     it("should generate the base schema with placeholder if placeholder is added", () => {
         const placeholder = "This is a placeholder";
 
-        const MOCK_ELEMENT: INumericField = {
+        const mockElement: INumericField = {
             label,
             id: elementId,
             internalId: "numeric-field",
@@ -35,7 +35,7 @@ describe("NumericSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            NumericSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            NumericSchemaGenerator.elementToSchema(mockElement);
 
         expect(generatedSchema[elementId]).toHaveProperty(
             "placeholder",
@@ -47,7 +47,7 @@ describe("NumericSchemaGenerator", () => {
         const validationRule = "5";
         const validationErrorMessage = "The max value for this field is 5";
 
-        const MOCK_ELEMENT: INumericField = {
+        const mockElement: INumericField = {
             label,
             id: elementId,
             internalId: "numeric-field",
@@ -64,7 +64,7 @@ describe("NumericSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            NumericSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            NumericSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -91,7 +91,7 @@ describe("NumericSchemaGenerator", () => {
         const validationWholeNumbersErrorMessage =
             "This field only accepts whole numbers";
 
-        const MOCK_ELEMENT: INumericField = {
+        const mockElement: INumericField = {
             label,
             id: elementId,
             internalId: "numeric-field",
@@ -118,7 +118,7 @@ describe("NumericSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            NumericSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            NumericSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,

--- a/tests/util/translator/generate/elements/numeric/numeric-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/numeric/numeric-schema-generator.spec.tsx
@@ -24,8 +24,8 @@ describe("NumericSchemaGenerator", () => {
         const placeholder = "This is a placeholder";
 
         const mockElement: INumericField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "numeric-field",
             type: EElementType.NUMERIC,
             required: false,
@@ -37,7 +37,7 @@ describe("NumericSchemaGenerator", () => {
         const generatedSchema =
             NumericSchemaGenerator.elementToSchema(mockElement);
 
-        expect(generatedSchema[elementId]).toHaveProperty(
+        expect(generatedSchema[ELEMENT_ID]).toHaveProperty(
             "placeholder",
             placeholder
         );
@@ -48,8 +48,8 @@ describe("NumericSchemaGenerator", () => {
         const validationErrorMessage = "The max value for this field is 5";
 
         const mockElement: INumericField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "numeric-field",
             type: EElementType.NUMERIC,
             required: false,
@@ -67,9 +67,9 @@ describe("NumericSchemaGenerator", () => {
             NumericSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.NUMERIC,
             validation: [
@@ -92,12 +92,12 @@ describe("NumericSchemaGenerator", () => {
             "This field only accepts whole numbers";
 
         const mockElement: INumericField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "numeric-field",
             type: EElementType.NUMERIC,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             validation: [
                 {
@@ -121,15 +121,15 @@ describe("NumericSchemaGenerator", () => {
             NumericSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.NUMERIC,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
                 {
                     min: parseInt(validationMinRule),
@@ -154,6 +154,6 @@ describe("NumericSchemaGenerator", () => {
 // HELPERS
 // =============================================================================
 
-const elementId = "mockId123";
-const label = "Numbers";
-const requiredErrorMsg = "This field is required";
+const ELEMENT_ID = "mockId123";
+const LABEL = "Numbers";
+const REQUIRED_ERROR_MESSAGE = "This field is required";

--- a/tests/util/translator/generate/elements/numeric/numeric-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/numeric/numeric-schema-generator.spec.tsx
@@ -20,6 +20,29 @@ describe("NumericSchemaGenerator", () => {
         jest.resetAllMocks();
     });
 
+    it("should generate the base schema with placeholder if placeholder is added", () => {
+        const placeholder = "This is a placeholder";
+
+        const MOCK_ELEMENT: INumericField = {
+            label,
+            id: elementId,
+            internalId: "numeric-field",
+            type: EElementType.NUMERIC,
+            required: false,
+            columns: { desktop: 12, tablet: 8, mobile: 4 },
+            validation: [],
+            placeholder,
+        };
+
+        const generatedSchema =
+            NumericSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+
+        expect(generatedSchema[elementId]).toHaveProperty(
+            "placeholder",
+            placeholder
+        );
+    });
+
     it("should generate the base schema WITH only additional validation if additional validation is added but required is false", () => {
         const validationRule = "5";
         const validationErrorMessage = "The max value for this field is 5";

--- a/tests/util/translator/generate/elements/text/text-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/text/text-schema-generator.spec.tsx
@@ -20,6 +20,29 @@ describe("TextSchemaGenerator", () => {
         jest.resetAllMocks();
     });
 
+    it("should generate the base schema with placeholder if placeholder is added", () => {
+        const placeholder = "This is a placeholder";
+
+        const MOCK_ELEMENT: ITextField = {
+            label,
+            id: elementId,
+            internalId: "text-field",
+            type: EElementType.TEXT,
+            required: false,
+            columns: { desktop: 12, tablet: 8, mobile: 4 },
+            validation: [],
+            placeholder,
+        };
+
+        const generatedSchema =
+            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+
+        expect(generatedSchema[elementId]).toHaveProperty(
+            "placeholder",
+            placeholder
+        );
+    });
+
     it("should generate the base schema WITH only additional validation if additional validation is added but required is false", () => {
         const validationRule = "5";
         const validationErrorMessage =

--- a/tests/util/translator/generate/elements/text/text-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/text/text-schema-generator.spec.tsx
@@ -24,8 +24,8 @@ describe("TextSchemaGenerator", () => {
         const placeholder = "This is a placeholder";
 
         const mockElement: ITextField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: false,
@@ -37,7 +37,7 @@ describe("TextSchemaGenerator", () => {
         const generatedSchema =
             TextSchemaGenerator.elementToSchema(mockElement);
 
-        expect(generatedSchema[elementId]).toHaveProperty(
+        expect(generatedSchema[ELEMENT_ID]).toHaveProperty(
             "placeholder",
             placeholder
         );
@@ -49,8 +49,8 @@ describe("TextSchemaGenerator", () => {
             "This field must be at least 5 characters long";
 
         const mockElement: ITextField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: false,
@@ -68,9 +68,9 @@ describe("TextSchemaGenerator", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXT,
             validation: [
@@ -98,12 +98,12 @@ describe("TextSchemaGenerator", () => {
             "This field must start with 'hello'";
 
         const mockElement: ITextField = {
-            label,
-            id: elementId,
+            label: LABEL,
+            id: ELEMENT_ID,
             internalId: "text-field",
             type: EElementType.TEXT,
             required: true,
-            requiredErrorMsg,
+            requiredErrorMsg: REQUIRED_ERROR_MESSAGE,
             columns: { desktop: 12, tablet: 8, mobile: 4 },
             validation: [
                 {
@@ -128,15 +128,15 @@ describe("TextSchemaGenerator", () => {
             TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
-            id: elementId,
+            id: ELEMENT_ID,
             label: {
-                mainLabel: label,
+                mainLabel: LABEL,
             },
             uiType: EElementType.TEXT,
             validation: [
                 {
                     required: true,
-                    errorMessage: requiredErrorMsg,
+                    errorMessage: REQUIRED_ERROR_MESSAGE,
                 },
                 {
                     min: parseInt(validationMinRule),
@@ -160,6 +160,6 @@ describe("TextSchemaGenerator", () => {
 // =============================================================================
 // HELPERS
 // =============================================================================
-const elementId = "mockId123";
-const label = "Text Field";
-const requiredErrorMsg = "This field is required";
+const ELEMENT_ID = "mockId123";
+const LABEL = "Text Field";
+const REQUIRED_ERROR_MESSAGE = "This field is required";

--- a/tests/util/translator/generate/elements/text/text-schema-generator.spec.tsx
+++ b/tests/util/translator/generate/elements/text/text-schema-generator.spec.tsx
@@ -23,7 +23,7 @@ describe("TextSchemaGenerator", () => {
     it("should generate the base schema with placeholder if placeholder is added", () => {
         const placeholder = "This is a placeholder";
 
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             label,
             id: elementId,
             internalId: "text-field",
@@ -35,7 +35,7 @@ describe("TextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         expect(generatedSchema[elementId]).toHaveProperty(
             "placeholder",
@@ -48,7 +48,7 @@ describe("TextSchemaGenerator", () => {
         const validationErrorMessage =
             "This field must be at least 5 characters long";
 
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             label,
             id: elementId,
             internalId: "text-field",
@@ -65,7 +65,7 @@ describe("TextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,
@@ -97,7 +97,7 @@ describe("TextSchemaGenerator", () => {
         const validationRegexErrorMessage =
             "This field must start with 'hello'";
 
-        const MOCK_ELEMENT: ITextField = {
+        const mockElement: ITextField = {
             label,
             id: elementId,
             internalId: "text-field",
@@ -125,7 +125,7 @@ describe("TextSchemaGenerator", () => {
         };
 
         const generatedSchema =
-            TextSchemaGenerator.elementToSchema(MOCK_ELEMENT);
+            TextSchemaGenerator.elementToSchema(mockElement);
 
         const expectedSchema = generateMockElementSchema({
             id: elementId,


### PR DESCRIPTION
This branch extracts the `placeholder` attribute from the base schema generator since realising not all element types have placeholder (Yes/No element as of now). It also covers the renaming of consts in the test cases related to schema generating from UPPER_SNAKE_CASE  to camelCase.

**Changes**

- Extract placeholder from base schema generator. 
- Add test cases for placeholder.
- Remove default case from setDefaultValidationType.
- Rename consts used in functions to be camelCase.


**Additional information**

-   You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-1512)
-   Any other information you would like to include
